### PR TITLE
Fix: Trap impatient call to enable bootstrap

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,5 +1,9 @@
 -- impatient has to be loaded before anything else
-require('impatient')
+local present, impatient = pcall(require, 'impatient')
+if present then
+  impatient.enable_profile()
+end
+
 require('disable-builtins')
 require('settings')
 require('plugins')


### PR DESCRIPTION
You need to trap your impatient call before nvim will bootstrap on a new/clean system.
This is one possible solution; there are others, of course...